### PR TITLE
fix: toKeplrChainInfo undefined currency decimals

### DIFF
--- a/src/registry/keplr/toKeplrChainInfo.ts
+++ b/src/registry/keplr/toKeplrChainInfo.ts
@@ -52,9 +52,9 @@ export function toKeplrChainInfo(
   const currencies: Currency[] = chainRegistryAssetList.assets.map((asset) => ({
     coinDenom: asset.symbol,
     coinMinimalDenom: asset.base,
-    coinDecimals: asset.denom_units.filter(
+    coinDecimals: asset.denom_units.find(
       (denomUnit: { denom: string }) => denomUnit.denom === asset.display
-    )[0]?.exponent,
+    )?.exponent ?? 6,
     coinGeckoId: asset.coingecko_id,
     coinImageUrl: asset.logo_URIs?.svg ?? asset.logo_URIs?.png,
   }));


### PR DESCRIPTION
Potentially might be not found if assetlist has issues.

I think having it default to `6` would be better as its more common than `0`