### PR TITLE
fix: coingecko id empty string

### DIFF
--- a/src/registry/keplr/toKeplrChainInfo.ts
+++ b/src/registry/keplr/toKeplrChainInfo.ts
@@ -55,7 +55,7 @@ export function toKeplrChainInfo(
     coinDecimals: asset.denom_units.find(
       (denomUnit: { denom: string }) => denomUnit.denom === asset.display
     )?.exponent ?? 6,
-    coinGeckoId: asset.coingecko_id,
+    coinGeckoId: asset.coingecko_id === "" ? undefined : asset.coingecko_id,
     coinImageUrl: asset.logo_URIs?.svg ?? asset.logo_URIs?.png,
   }));
 


### PR DESCRIPTION
Keplr throws error `Error: "currencies[n]" does not match any of the allowed types` when using chain info with currencies that have `coinGeckoId: ""` instead of `undefined` such as [Sei asset in chain registry](https://github.com/cosmos/chain-registry/blob/master/sei/assetlist.json#L53)