### PR TITLE
fix: add default sign options to wallet connect sign funcs

### DIFF
--- a/src/wallet/walletconnect/WalletConnectV2.ts
+++ b/src/wallet/walletconnect/WalletConnectV2.ts
@@ -56,6 +56,11 @@ const Event = {
 } as const;
 type Event = (typeof Event)[keyof typeof Event];
 
+const DEFAULT_SIGN_OPTIONS = {
+  preferNoSetFee: true,
+  preferNoSetMemo: true,
+};
+
 export class WalletConnectV2 {
   private readonly projectId: string;
   private readonly mobileAppDetails: MobileAppDetails;
@@ -191,6 +196,7 @@ export class WalletConnectV2 {
       {
         signerAddress,
         signDoc: stdSignDoc,
+        signOptions: DEFAULT_SIGN_OPTIONS,
       }
     );
     return {
@@ -210,6 +216,7 @@ export class WalletConnectV2 {
       {
         signerAddress,
         signDoc,
+        signOptions: DEFAULT_SIGN_OPTIONS,
       }
     );
     return {


### PR DESCRIPTION
This PR adds the `preferNoSetFee` and `preferNoSetMemo` options hardcoded to `true` to the `WalletConnectV2` class. See #61 for the relevant issue. If tested to be working, this PR should take precedence over #71 as this implementation is much simpler.

- Closes #61
- Closes #71